### PR TITLE
Make Landsat Compatible with Collection 2 Products

### DIFF
--- a/arcsilib/arcsisensorlandsat1mss.py
+++ b/arcsilib/arcsisensorlandsat1mss.py
@@ -75,6 +75,8 @@ from rios import rat
 import json
 # Import the solar angle tools from RSGISLib
 import rsgislib.imagecalibration.solarangles
+import rsgislib.segmentation
+import rsgislib.segmentation.segutils
 
 class ARCSILandsat1MSSSensor (ARCSIAbstractSensor):
     """
@@ -241,8 +243,7 @@ class ARCSILandsat1MSSSensor (ARCSIAbstractSensor):
             if "GRID_CELL_SIZE_REFLECTIVE" in headerParams:
                 self.gridCellSizeRefl = arcsiUtils.str2Float(headerParams["GRID_CELL_SIZE_REFLECTIVE"], 60.0)
 
-            fileDateStr = headerParams["FILE_DATE"].strip()
-            fileDateStr = fileDateStr.replace('Z', '')
+            fileDateStr = f"{headerParams['DATE_ACQUIRED'].strip()}T{headerParams['SCENE_CENTER_TIME'].split('.')[0]}"
             self.fileDateObj = datetime.datetime.strptime(fileDateStr, "%Y-%m-%dT%H:%M:%S")
 
         except Exception as e:
@@ -608,6 +609,7 @@ class ARCSILandsat1MSSSensor (ARCSIAbstractSensor):
                 dosBlueImage = self.performLocalDOSOnSingleBand(inputTOAImage, 1, outputPath, tmpBaseName, "Blue", "KEA", tmpPath, minObjSize, darkPxlPercentile, blockSize, dosOutRefl)
 
             thresImageClumpsFinal = os.path.join(tmpPath, tmpBaseName + "_clumps" + imgExtension)
+
             rsgislib.segmentation.segutils.runShepherdSegmentation(inputTOAImage, thresImageClumpsFinal, tmpath=tmpPath, gdalformat="KEA", numClusters=40, minPxls=10, bands=[1,2,3,4], processInMem=True)
 
             stats2CalcTOA = list()

--- a/arcsilib/arcsisensorlandsat1mss.py
+++ b/arcsilib/arcsisensorlandsat1mss.py
@@ -437,7 +437,7 @@ class ARCSILandsat1MSSSensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B1)
         s.run()
         sixsCoeffs[0,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[0,1] = float(s.outputs.values['coef_xb'])
@@ -447,7 +447,7 @@ class ARCSILandsat1MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[0,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 2
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B2)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B2)
         s.run()
         sixsCoeffs[1,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[1,1] = float(s.outputs.values['coef_xb'])
@@ -457,7 +457,7 @@ class ARCSILandsat1MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[1,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 3
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B3)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B3)
         s.run()
         sixsCoeffs[2,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[2,1] = float(s.outputs.values['coef_xb'])
@@ -467,7 +467,7 @@ class ARCSILandsat1MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[2,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 4
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B4)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B4)
         s.run()
         sixsCoeffs[3,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[3,1] = float(s.outputs.values['coef_xb'])
@@ -568,7 +568,7 @@ class ARCSILandsat1MSSSensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1 (Blue!)
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B1)
         s.run()
         aX = float(s.outputs.values['coef_xa'])
         bX = float(s.outputs.values['coef_xb'])

--- a/arcsilib/arcsisensorlandsat2mss.py
+++ b/arcsilib/arcsisensorlandsat2mss.py
@@ -75,6 +75,8 @@ from rios import rat
 import json
 # Import the solar angle tools from RSGISLib
 import rsgislib.imagecalibration.solarangles
+import rsgislib.segmentation
+import rsgislib.segmentation.segutils
 
 class ARCSILandsat2MSSSensor (ARCSIAbstractSensor):
     """
@@ -241,8 +243,7 @@ class ARCSILandsat2MSSSensor (ARCSIAbstractSensor):
             if "GRID_CELL_SIZE_REFLECTIVE" in headerParams:
                 self.gridCellSizeRefl = arcsiUtils.str2Float(headerParams["GRID_CELL_SIZE_REFLECTIVE"], 60.0)
 
-            fileDateStr = headerParams["FILE_DATE"].strip()
-            fileDateStr = fileDateStr.replace('Z', '')
+            fileDateStr = f"{headerParams['DATE_ACQUIRED'].strip()}T{headerParams['SCENE_CENTER_TIME'].split('.')[0]}"
             self.fileDateObj = datetime.datetime.strptime(fileDateStr, "%Y-%m-%dT%H:%M:%S")
 
         except Exception as e:

--- a/arcsilib/arcsisensorlandsat2mss.py
+++ b/arcsilib/arcsisensorlandsat2mss.py
@@ -437,7 +437,7 @@ class ARCSILandsat2MSSSensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B1)
         s.run()
         sixsCoeffs[0,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[0,1] = float(s.outputs.values['coef_xb'])
@@ -447,7 +447,7 @@ class ARCSILandsat2MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[0,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 2
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B2)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B2)
         s.run()
         sixsCoeffs[1,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[1,1] = float(s.outputs.values['coef_xb'])
@@ -457,7 +457,7 @@ class ARCSILandsat2MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[1,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 3
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B3)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B3)
         s.run()
         sixsCoeffs[2,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[2,1] = float(s.outputs.values['coef_xb'])
@@ -467,7 +467,7 @@ class ARCSILandsat2MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[2,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 4
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B4)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B4)
         s.run()
         sixsCoeffs[3,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[3,1] = float(s.outputs.values['coef_xb'])
@@ -568,7 +568,7 @@ class ARCSILandsat2MSSSensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1 (Blue!)
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B1)
         s.run()
         aX = float(s.outputs.values['coef_xa'])
         bX = float(s.outputs.values['coef_xb'])

--- a/arcsilib/arcsisensorlandsat3mss.py
+++ b/arcsilib/arcsisensorlandsat3mss.py
@@ -75,6 +75,8 @@ from rios import rat
 import json
 # Import the solar angle tools from RSGISLib
 import rsgislib.imagecalibration.solarangles
+import rsgislib.segmentation
+import rsgislib.segmentation.segutils
 
 class ARCSILandsat3MSSSensor (ARCSIAbstractSensor):
     """
@@ -241,8 +243,7 @@ class ARCSILandsat3MSSSensor (ARCSIAbstractSensor):
             if "GRID_CELL_SIZE_REFLECTIVE" in headerParams:
                 self.gridCellSizeRefl = arcsiUtils.str2Float(headerParams["GRID_CELL_SIZE_REFLECTIVE"], 60.0)
 
-            fileDateStr = headerParams["FILE_DATE"].strip()
-            fileDateStr = fileDateStr.replace('Z', '')
+            fileDateStr = f"{headerParams['DATE_ACQUIRED'].strip()}T{headerParams['SCENE_CENTER_TIME'].split('.')[0]}"
             self.fileDateObj = datetime.datetime.strptime(fileDateStr, "%Y-%m-%dT%H:%M:%S")
 
         except Exception as e:

--- a/arcsilib/arcsisensorlandsat3mss.py
+++ b/arcsilib/arcsisensorlandsat3mss.py
@@ -437,7 +437,7 @@ class ARCSILandsat3MSSSensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B1)
         s.run()
         sixsCoeffs[0,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[0,1] = float(s.outputs.values['coef_xb'])
@@ -447,7 +447,7 @@ class ARCSILandsat3MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[0,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 2
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B2)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B2)
         s.run()
         sixsCoeffs[1,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[1,1] = float(s.outputs.values['coef_xb'])
@@ -457,7 +457,7 @@ class ARCSILandsat3MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[1,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 3
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B3)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B3)
         s.run()
         sixsCoeffs[2,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[2,1] = float(s.outputs.values['coef_xb'])
@@ -467,7 +467,7 @@ class ARCSILandsat3MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[2,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 4
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B4)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B4)
         s.run()
         sixsCoeffs[3,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[3,1] = float(s.outputs.values['coef_xb'])
@@ -568,7 +568,7 @@ class ARCSILandsat3MSSSensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1 (Blue!)
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B1)
         s.run()
         aX = float(s.outputs.values['coef_xa'])
         bX = float(s.outputs.values['coef_xb'])

--- a/arcsilib/arcsisensorlandsat4mss.py
+++ b/arcsilib/arcsisensorlandsat4mss.py
@@ -437,7 +437,7 @@ class ARCSILandsat4MSSSensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B1)
         s.run()
         sixsCoeffs[0,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[0,1] = float(s.outputs.values['coef_xb'])
@@ -447,7 +447,7 @@ class ARCSILandsat4MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[0,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 2
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B2)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B2)
         s.run()
         sixsCoeffs[1,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[1,1] = float(s.outputs.values['coef_xb'])
@@ -457,7 +457,7 @@ class ARCSILandsat4MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[1,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 3
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B3)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B3)
         s.run()
         sixsCoeffs[2,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[2,1] = float(s.outputs.values['coef_xb'])
@@ -467,7 +467,7 @@ class ARCSILandsat4MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[2,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 4
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B4)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B4)
         s.run()
         sixsCoeffs[3,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[3,1] = float(s.outputs.values['coef_xb'])
@@ -568,7 +568,7 @@ class ARCSILandsat4MSSSensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1 (Blue!)
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B1)
         s.run()
         aX = float(s.outputs.values['coef_xa'])
         bX = float(s.outputs.values['coef_xb'])

--- a/arcsilib/arcsisensorlandsat4mss.py
+++ b/arcsilib/arcsisensorlandsat4mss.py
@@ -75,6 +75,8 @@ from rios import rat
 import json
 # Import the solar angle tools from RSGISLib
 import rsgislib.imagecalibration.solarangles
+import rsgislib.segmentation
+import rsgislib.segmentation.segutils
 
 class ARCSILandsat4MSSSensor (ARCSIAbstractSensor):
     """
@@ -241,8 +243,7 @@ class ARCSILandsat4MSSSensor (ARCSIAbstractSensor):
             if "GRID_CELL_SIZE_REFLECTIVE" in headerParams:
                 self.gridCellSizeRefl = arcsiUtils.str2Float(headerParams["GRID_CELL_SIZE_REFLECTIVE"], 60.0)
 
-            fileDateStr = headerParams["FILE_DATE"].strip()
-            fileDateStr = fileDateStr.replace('Z', '')
+            fileDateStr = f"{headerParams['DATE_ACQUIRED'].strip()}T{headerParams['SCENE_CENTER_TIME'].split('.')[0]}"
             self.fileDateObj = datetime.datetime.strptime(fileDateStr, "%Y-%m-%dT%H:%M:%S")
 
         except Exception as e:

--- a/arcsilib/arcsisensorlandsat4tm.py
+++ b/arcsilib/arcsisensorlandsat4tm.py
@@ -84,6 +84,8 @@ import fmask.landsatangles
 import fmask.config
 import fmask.fmask
 import rios.fileinfo
+import rsgislib.segmentation
+import rsgislib.segmentation.segutils
 
 class ARCSILandsat4TMSensor (ARCSIAbstractSensor):
     """
@@ -242,10 +244,13 @@ class ARCSILandsat4TMSensor (ARCSIAbstractSensor):
             self.band7File = os.path.join(filesDIR, headerParams["FILE_NAME_BAND_7"])
 
             try:
-                self.bandQAFile = os.path.join(filesDIR, headerParams["FILE_NAME_BAND_QUALITY"])
+                self.bandQAFile = os.path.join(filesDIR, headerParams["FILE_NAME_QUALITY_L1_PIXEL"])
             except KeyError:
-                print("Warning - the quality band is not available. Are you using collection 1 data?")
-                self.bandQAFile = ""
+                try:
+                    self.bandQAFile = os.path.join(filesDIR, headerParams["FILE_NAME_BAND_QUALITY"])
+                except KeyError:
+                    print("Warning - the quality band is not available. Pre-collection 1 data unsupported")
+                    self.bandQAFile = ""
 
             self.b1CalMin = arcsiUtils.str2Float(headerParams["QUANTIZE_CAL_MIN_BAND_1"], 1.0)
             self.b1CalMax = arcsiUtils.str2Float(headerParams["QUANTIZE_CAL_MAX_BAND_1"], 255.0)
@@ -291,8 +296,7 @@ class ARCSILandsat4TMSensor (ARCSIAbstractSensor):
             # Read MTL header into python dict for python-fmask
             self.fmaskMTLInfo = fmask.config.readMTLFile(inputHeader)
 
-            fileDateStr = headerParams["FILE_DATE"].strip()
-            fileDateStr = fileDateStr.replace('Z', '')
+            fileDateStr = f"{headerParams['DATE_ACQUIRED'].strip()}T{headerParams['SCENE_CENTER_TIME'].split('.')[0]}"
             self.fileDateObj = datetime.datetime.strptime(fileDateStr, "%Y-%m-%dT%H:%M:%S")
 
         except Exception as e:

--- a/arcsilib/arcsisensorlandsat4tm.py
+++ b/arcsilib/arcsisensorlandsat4tm.py
@@ -630,7 +630,7 @@ class ARCSILandsat4TMSensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_TM_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_TM_B1)
         s.run()
         sixsCoeffs[0,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[0,1] = float(s.outputs.values['coef_xb'])
@@ -640,7 +640,7 @@ class ARCSILandsat4TMSensor (ARCSIAbstractSensor):
         sixsCoeffs[0,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 2
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_TM_B2)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_TM_B2)
         s.run()
         sixsCoeffs[1,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[1,1] = float(s.outputs.values['coef_xb'])
@@ -650,7 +650,7 @@ class ARCSILandsat4TMSensor (ARCSIAbstractSensor):
         sixsCoeffs[1,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 3
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_TM_B3)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_TM_B3)
         s.run()
         sixsCoeffs[2,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[2,1] = float(s.outputs.values['coef_xb'])
@@ -660,7 +660,7 @@ class ARCSILandsat4TMSensor (ARCSIAbstractSensor):
         sixsCoeffs[2,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 4
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_TM_B4)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_TM_B4)
         s.run()
         sixsCoeffs[3,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[3,1] = float(s.outputs.values['coef_xb'])
@@ -670,7 +670,7 @@ class ARCSILandsat4TMSensor (ARCSIAbstractSensor):
         sixsCoeffs[3,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 5
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_TM_B5)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_TM_B5)
         s.run()
         sixsCoeffs[4,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[4,1] = float(s.outputs.values['coef_xb'])
@@ -680,7 +680,7 @@ class ARCSILandsat4TMSensor (ARCSIAbstractSensor):
         sixsCoeffs[4,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 6
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_TM_B7)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_TM_B7)
         s.run()
         sixsCoeffs[5,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[5,1] = float(s.outputs.values['coef_xb'])
@@ -787,7 +787,7 @@ class ARCSILandsat4TMSensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1 (Blue!)
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_TM_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_TM_B1)
         s.run()
         aX = float(s.outputs.values['coef_xa'])
         bX = float(s.outputs.values['coef_xb'])

--- a/arcsilib/arcsisensorlandsat5mss.py
+++ b/arcsilib/arcsisensorlandsat5mss.py
@@ -441,7 +441,7 @@ class ARCSILandsat5MSSSensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B1)
         s.run()
         sixsCoeffs[0,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[0,1] = float(s.outputs.values['coef_xb'])
@@ -451,7 +451,7 @@ class ARCSILandsat5MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[0,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 2
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B2)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B2)
         s.run()
         sixsCoeffs[1,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[1,1] = float(s.outputs.values['coef_xb'])
@@ -461,7 +461,7 @@ class ARCSILandsat5MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[1,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 3
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B3)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B3)
         s.run()
         sixsCoeffs[2,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[2,1] = float(s.outputs.values['coef_xb'])
@@ -471,7 +471,7 @@ class ARCSILandsat5MSSSensor (ARCSIAbstractSensor):
         sixsCoeffs[2,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 4
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B4)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B4)
         s.run()
         sixsCoeffs[3,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[3,1] = float(s.outputs.values['coef_xb'])
@@ -572,7 +572,7 @@ class ARCSILandsat5MSSSensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1 (Blue!)
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_MSS_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_MSS_B1)
         s.run()
         aX = float(s.outputs.values['coef_xa'])
         bX = float(s.outputs.values['coef_xb'])

--- a/arcsilib/arcsisensorlandsat5mss.py
+++ b/arcsilib/arcsisensorlandsat5mss.py
@@ -75,6 +75,8 @@ from rios import rat
 import json
 # Import the solar angle tools from RSGISLib
 import rsgislib.imagecalibration.solarangles
+import rsgislib.segmentation
+import rsgislib.segmentation.segutils
 
 class ARCSILandsat5MSSSensor (ARCSIAbstractSensor):
     """
@@ -245,8 +247,7 @@ class ARCSILandsat5MSSSensor (ARCSIAbstractSensor):
             if "GRID_CELL_SIZE_REFLECTIVE" in headerParams:
                 self.gridCellSizeRefl = arcsiUtils.str2Float(headerParams["GRID_CELL_SIZE_REFLECTIVE"], 60.0)
 
-            fileDateStr = headerParams["FILE_DATE"].strip()
-            fileDateStr = fileDateStr.replace('Z', '')
+            fileDateStr = f"{headerParams['DATE_ACQUIRED'].strip()}T{headerParams['SCENE_CENTER_TIME'].split('.')[0]}"
             self.fileDateObj = datetime.datetime.strptime(fileDateStr, "%Y-%m-%dT%H:%M:%S")
 
         except Exception as e:

--- a/arcsilib/arcsisensorlandsat5tm.py
+++ b/arcsilib/arcsisensorlandsat5tm.py
@@ -686,7 +686,7 @@ class ARCSILandsat5TMSensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_TM_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_TM_B1)
         s.run()
         sixsCoeffs[0,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[0,1] = float(s.outputs.values['coef_xb'])
@@ -696,7 +696,7 @@ class ARCSILandsat5TMSensor (ARCSIAbstractSensor):
         sixsCoeffs[0,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 2
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_TM_B2)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_TM_B2)
         s.run()
         sixsCoeffs[1,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[1,1] = float(s.outputs.values['coef_xb'])
@@ -706,7 +706,7 @@ class ARCSILandsat5TMSensor (ARCSIAbstractSensor):
         sixsCoeffs[1,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 3
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_TM_B3)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_TM_B3)
         s.run()
         sixsCoeffs[2,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[2,1] = float(s.outputs.values['coef_xb'])
@@ -716,7 +716,7 @@ class ARCSILandsat5TMSensor (ARCSIAbstractSensor):
         sixsCoeffs[2,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 4
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_TM_B4)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_TM_B4)
         s.run()
         sixsCoeffs[3,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[3,1] = float(s.outputs.values['coef_xb'])
@@ -726,7 +726,7 @@ class ARCSILandsat5TMSensor (ARCSIAbstractSensor):
         sixsCoeffs[3,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 5
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_TM_B5)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_TM_B5)
         s.run()
         sixsCoeffs[4,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[4,1] = float(s.outputs.values['coef_xb'])
@@ -736,7 +736,7 @@ class ARCSILandsat5TMSensor (ARCSIAbstractSensor):
         sixsCoeffs[4,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 6
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_TM_B7)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_TM_B7)
         s.run()
         sixsCoeffs[5,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[5,1] = float(s.outputs.values['coef_xb'])
@@ -843,7 +843,7 @@ class ARCSILandsat5TMSensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1 (Blue!)
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_TM_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_TM_B1)
         s.run()
         aX = float(s.outputs.values['coef_xa'])
         bX = float(s.outputs.values['coef_xb'])

--- a/arcsilib/arcsisensorlandsat5tm.py
+++ b/arcsilib/arcsisensorlandsat5tm.py
@@ -277,10 +277,13 @@ class ARCSILandsat5TMSensor (ARCSIAbstractSensor):
             self.band7File = os.path.join(filesDIR, metaFilenames[6])
 
             try:
-                self.bandQAFile = os.path.join(filesDIR, headerParams["FILE_NAME_BAND_QUALITY"])
+                self.bandQAFile = os.path.join(filesDIR, headerParams["FILE_NAME_QUALITY_L1_PIXEL"])
             except KeyError:
-                print("Warning - the quality band is not available. Are you using collection 1 data?")
-                self.bandQAFile = ""
+                try:
+                    self.bandQAFile = os.path.join(filesDIR, headerParams["FILE_NAME_BAND_QUALITY"])
+                except KeyError:
+                    print("Warning - the quality band is not available. Pre-collection 1 data unsupported")
+                    self.bandQAFile = ""
 
             metaQCalMinList = []
             metaQCalMaxList = []
@@ -346,8 +349,7 @@ class ARCSILandsat5TMSensor (ARCSIAbstractSensor):
             if "GRID_CELL_SIZE_THERMAL" in headerParams:
                 self.gridCellSizeTherm = arcsiUtils.str2Float(headerParams["GRID_CELL_SIZE_THERMAL"], 30.0)
 
-            fileDateStr = headerParams["FILE_DATE"].strip()
-            fileDateStr = fileDateStr.replace('Z', '')
+            fileDateStr = f"{headerParams['DATE_ACQUIRED'].strip()}T{headerParams['SCENE_CENTER_TIME'].split('.')[0]}"
             self.fileDateObj = datetime.datetime.strptime(fileDateStr, "%Y-%m-%dT%H:%M:%S")
 
             # Read MTL header into python dict for python-fmask

--- a/arcsilib/arcsisensorlandsat7.py
+++ b/arcsilib/arcsisensorlandsat7.py
@@ -820,7 +820,7 @@ class ARCSILandsat7Sensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_ETM_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_ETM_B1)
         s.run()
         sixsCoeffs[0,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[0,1] = float(s.outputs.values['coef_xb'])
@@ -830,7 +830,7 @@ class ARCSILandsat7Sensor (ARCSIAbstractSensor):
         sixsCoeffs[0,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 2
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_ETM_B2)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_ETM_B2)
         s.run()
         sixsCoeffs[1,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[1,1] = float(s.outputs.values['coef_xb'])
@@ -840,7 +840,7 @@ class ARCSILandsat7Sensor (ARCSIAbstractSensor):
         sixsCoeffs[1,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 3
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_ETM_B3)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_ETM_B3)
         s.run()
         sixsCoeffs[2,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[2,1] = float(s.outputs.values['coef_xb'])
@@ -850,7 +850,7 @@ class ARCSILandsat7Sensor (ARCSIAbstractSensor):
         sixsCoeffs[2,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 4
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_ETM_B4)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_ETM_B4)
         s.run()
         sixsCoeffs[3,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[3,1] = float(s.outputs.values['coef_xb'])
@@ -860,7 +860,7 @@ class ARCSILandsat7Sensor (ARCSIAbstractSensor):
         sixsCoeffs[3,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 5
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_ETM_B5)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_ETM_B5)
         s.run()
         sixsCoeffs[4,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[4,1] = float(s.outputs.values['coef_xb'])
@@ -870,7 +870,7 @@ class ARCSILandsat7Sensor (ARCSIAbstractSensor):
         sixsCoeffs[4,5] = float(s.outputs.values['environmental_irradiance'])
 
         # Band 7
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_ETM_B7)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_ETM_B7)
         s.run()
         sixsCoeffs[5,0] = float(s.outputs.values['coef_xa'])
         sixsCoeffs[5,1] = float(s.outputs.values['coef_xb'])
@@ -977,7 +977,7 @@ class ARCSILandsat7Sensor (ARCSIAbstractSensor):
         s.aot550 = aotVal
 
         # Band 1 (Blue!)
-        s.wavelength = Py6S.Wavelength(Py6S.SixSHelpers.PredefinedWavelengths.LANDSAT_ETM_B1)
+        s.wavelength = Py6S.Wavelength(Py6S.Params.PredefinedWavelengths.LANDSAT_ETM_B1)
         s.run()
         aX = float(s.outputs.values['coef_xa'])
         bX = float(s.outputs.values['coef_xb'])

--- a/arcsilib/arcsisensorlandsat7.py
+++ b/arcsilib/arcsisensorlandsat7.py
@@ -90,6 +90,8 @@ import fmask.landsatangles
 import fmask.config
 import fmask.fmask
 import rios.fileinfo
+import rsgislib.segmentation
+import rsgislib.segmentation.segutils
 
 class ARCSILandsat7Sensor (ARCSIAbstractSensor):
     """
@@ -290,11 +292,15 @@ class ARCSILandsat7Sensor (ARCSIAbstractSensor):
             self.band5File = os.path.join(filesDIR, metaFilenames[4])
             self.band7File = os.path.join(filesDIR, metaFilenames[6])
             self.bandPanFile = os.path.join(filesDIR, metaFilenames[7])
+
             try:
-                self.bandQAFile = os.path.join(filesDIR, headerParams["FILE_NAME_BAND_QUALITY"])
+                self.bandQAFile = os.path.join(filesDIR, headerParams["FILE_NAME_QUALITY_L1_PIXEL"])
             except KeyError:
-                print("Warning - the quality band is not available. Are you using collection 1 data?")
-                self.bandQAFile = ""
+                try:
+                    self.bandQAFile = os.path.join(filesDIR, headerParams["FILE_NAME_BAND_QUALITY"])
+                except KeyError:
+                    print("Warning - the quality band is not available. Pre-collection 1 data unsupported.")
+                    self.bandQAFile = ""
 
             try:
                 self.band6aFile = os.path.join(filesDIR,headerParams["FILE_NAME_BAND_6_VCID_1"])
@@ -404,8 +410,7 @@ class ARCSILandsat7Sensor (ARCSIAbstractSensor):
             # Read MTL header into python dict for python-fmask
             self.fmaskMTLInfo = fmask.config.readMTLFile(inputHeader)
 
-            fileDateStr = headerParams["FILE_DATE"].strip()
-            fileDateStr = fileDateStr.replace('Z', '')
+            fileDateStr = f"{headerParams['DATE_ACQUIRED'].strip()}T{headerParams['SCENE_CENTER_TIME'].split('.')[0]}"
             self.fileDateObj = datetime.datetime.strptime(fileDateStr, "%Y-%m-%dT%H:%M:%S")
 
         except Exception as e:

--- a/arcsilib/arcsisensorlandsat8.py
+++ b/arcsilib/arcsisensorlandsat8.py
@@ -296,7 +296,11 @@ class ARCSILandsat8Sensor (ARCSIAbstractSensor):
             self.band9File = os.path.join(filesDIR, headerParams["FILE_NAME_BAND_9"])
             self.band10File = os.path.join(filesDIR, headerParams["FILE_NAME_BAND_10"])
             self.band11File = os.path.join(filesDIR, headerParams["FILE_NAME_BAND_11"])
-            self.bandQAFile = os.path.join(filesDIR, headerParams["FILE_NAME_BAND_QUALITY"])
+
+            try:
+                self.bandQAFile = os.path.join(filesDIR, headerParams["FILE_NAME_QUALITY_L1_PIXEL"])
+            except KeyError:
+                self.bandQAFile = os.path.join(filesDIR, headerParams["FILE_NAME_BAND_QUALITY"])
 
             self.b1RadMulti = arcsiUtils.str2Float(headerParams["RADIANCE_MULT_BAND_1"])
             self.b2RadMulti = arcsiUtils.str2Float(headerParams["RADIANCE_MULT_BAND_2"])
@@ -386,8 +390,7 @@ class ARCSILandsat8Sensor (ARCSIAbstractSensor):
             # Read MTL header into python dict for python-fmask
             self.fmaskMTLInfo = fmask.config.readMTLFile(inputHeader)
 
-            fileDateStr = headerParams["FILE_DATE"].strip()
-            fileDateStr = fileDateStr.replace('Z', '')
+            fileDateStr = f"{headerParams['DATE_ACQUIRED'].strip()}T{headerParams['SCENE_CENTER_TIME'].split('.')[0]}"
             self.fileDateObj = datetime.datetime.strptime(fileDateStr, "%Y-%m-%dT%H:%M:%S")
 
         except Exception as e:

--- a/arcsilib/arcsiutils.py
+++ b/arcsilib/arcsiutils.py
@@ -373,8 +373,8 @@ class ARCSIUtils (object):
         point = ogr.CreateGeometryFromWkt(wktPt)
         point.AssignSpatialReference(inProjObj)
         point.TransformTo(wgs84latlonProj)
-        longVal = point.GetY() # The order is lat/long so it is flipped.
-        latVal = point.GetX() # The order is lat/long so it is flipped.
+        longVal = point.GetX()
+        latVal = point.GetY()
         return longVal, latVal
 
     def convertVisabilityToAOT(self, vis):


### PR DESCRIPTION
This changeset was created to allow Arcsi to process products from Landsat's Collection 2, which will become the standard Landsat format from 1st Jan 2022. The main changes in this regard are that FILE_DATE has now been removed from the metadata and FILE_NAME_BAND_QUALITY is now called FILE_NAME_QUALITY_L1_PIXEL

The changes allow backwards compatibility with metadata values from Collection 1 products

At least 1 scene for each Landsat sensor has been tested with DOSAOTSGL and SREF. Other products are untested but should be unaffected by these changes.

Changes are based on initial investigation and fix for Landsat 8 by :
Joe McGlinchy, Remote Sensing Scientist - CIRES Earth Lab, University of Colorado – Boulder

--

Also included:
- Changes to access PredefinedWavelengths from Py6S, which has seemingly changed in v1.9.0. Changes are compatible with older versions of this library.
- Swap X and Y order when getting longitude and latitude from GDAL as this was causing incorrect positioning of scenes for 6S
- Additional library imports for older sensors which could fail if functions from them were called
