### PR TITLE
Use generateOutputBaseName() for non-resampled bands for filename uni…

### DIFF
--- a/arcsilib/arcsisensorsentinel2.py
+++ b/arcsilib/arcsisensorsentinel2.py
@@ -2742,10 +2742,11 @@ class ARCSISentinel2Sensor(ARCSIAbstractSensor):
         img_band11_tmp = None
         img_band12_tmp = None
 
+        basename = self.generateOutputBaseName() # use a basename which has the generation time for uniqueness
+
         if abs(self.ratiometric_offs_B1) > 0:
-            basename = os.path.splitext(os.path.basename(img_band02))[0]
             img_band02_tmp = os.path.join(
-                outputPath, "{}_tmpoffapply.kea".format(basename)
+                outputPath, "{}_B02_tmpoffapply.kea".format(basename)
             )
             exp = "b1 + {}".format(self.ratiometric_offs_B1)
             rsgislib.imagecalc.image_math(
@@ -2754,9 +2755,8 @@ class ARCSISentinel2Sensor(ARCSIAbstractSensor):
             img_band02 = img_band02_tmp
 
         if abs(self.ratiometric_offs_B2) > 0:
-            basename = os.path.splitext(os.path.basename(img_band03))[0]
             img_band03_tmp = os.path.join(
-                outputPath, "{}_tmpoffapply.kea".format(basename)
+                outputPath, "{}_B03_tmpoffapply.kea".format(basename)
             )
             exp = "b1 + {}".format(self.ratiometric_offs_B2)
             rsgislib.imagecalc.image_math(
@@ -2765,9 +2765,8 @@ class ARCSISentinel2Sensor(ARCSIAbstractSensor):
             img_band03 = img_band03_tmp
 
         if abs(self.ratiometric_offs_B3) > 0:
-            basename = os.path.splitext(os.path.basename(img_band04))[0]
             img_band04_tmp = os.path.join(
-                outputPath, "{}_tmpoffapply.kea".format(basename)
+                outputPath, "{}_B04_tmpoffapply.kea".format(basename)
             )
             exp = "b1 + {}".format(self.ratiometric_offs_B3)
             rsgislib.imagecalc.image_math(
@@ -2776,9 +2775,8 @@ class ARCSISentinel2Sensor(ARCSIAbstractSensor):
             img_band04 = img_band04_tmp
 
         if abs(self.ratiometric_offs_B4) > 0:
-            basename = os.path.splitext(os.path.basename(img_band05))[0]
             img_band05_tmp = os.path.join(
-                outputPath, "{}_tmpoffapply.kea".format(basename)
+                outputPath, "{}_B05_tmpoffapply.kea".format(basename)
             )
             exp = "b1 + {}".format(self.ratiometric_offs_B4)
             rsgislib.imagecalc.image_math(
@@ -2787,9 +2785,8 @@ class ARCSISentinel2Sensor(ARCSIAbstractSensor):
             img_band05 = img_band05_tmp
 
         if abs(self.ratiometric_offs_B5) > 0:
-            basename = os.path.splitext(os.path.basename(img_band06))[0]
             img_band06_tmp = os.path.join(
-                outputPath, "{}_tmpoffapply.kea".format(basename)
+                outputPath, "{}_B06_tmpoffapply.kea".format(basename)
             )
             exp = "b1 + {}".format(self.ratiometric_offs_B5)
             rsgislib.imagecalc.image_math(
@@ -2798,9 +2795,8 @@ class ARCSISentinel2Sensor(ARCSIAbstractSensor):
             img_band06 = img_band06_tmp
 
         if abs(self.ratiometric_offs_B6) > 0:
-            basename = os.path.splitext(os.path.basename(img_band07))[0]
             img_band07_tmp = os.path.join(
-                outputPath, "{}_tmpoffapply.kea".format(basename)
+                outputPath, "{}_B07_tmpoffapply.kea".format(basename)
             )
             exp = "b1 + {}".format(self.ratiometric_offs_B6)
             rsgislib.imagecalc.image_math(
@@ -2809,9 +2805,8 @@ class ARCSISentinel2Sensor(ARCSIAbstractSensor):
             img_band07 = img_band07_tmp
 
         if abs(self.ratiometric_offs_B7) > 0:
-            basename = os.path.splitext(os.path.basename(img_band08))[0]
             img_band08_tmp = os.path.join(
-                outputPath, "{}_tmpoffapply.kea".format(basename)
+                outputPath, "{}_B08_tmpoffapply.kea".format(basename)
             )
             exp = "b1 + {}".format(self.ratiometric_offs_B7)
             rsgislib.imagecalc.image_math(
@@ -2820,9 +2815,8 @@ class ARCSISentinel2Sensor(ARCSIAbstractSensor):
             img_band08 = img_band08_tmp
 
         if abs(self.ratiometric_offs_B8) > 0:
-            basename = os.path.splitext(os.path.basename(img_band08A))[0]
             img_band08A_tmp = os.path.join(
-                outputPath, "{}_tmpoffapply.kea".format(basename)
+                outputPath, "{}_B8A_tmpoffapply.kea".format(basename)
             )
             exp = "b1 + {}".format(self.ratiometric_offs_B8)
             rsgislib.imagecalc.image_math(
@@ -2831,9 +2825,8 @@ class ARCSISentinel2Sensor(ARCSIAbstractSensor):
             img_band08A = img_band08A_tmp
 
         if abs(self.ratiometric_offs_B11) > 0:
-            basename = os.path.splitext(os.path.basename(img_band11))[0]
             img_band11_tmp = os.path.join(
-                outputPath, "{}_tmpoffapply.kea".format(basename)
+                outputPath, "{}_B11_tmpoffapply.kea".format(basename)
             )
             exp = "b1 + {}".format(self.ratiometric_offs_B11)
             rsgislib.imagecalc.image_math(
@@ -2842,9 +2835,8 @@ class ARCSISentinel2Sensor(ARCSIAbstractSensor):
             img_band11 = img_band11_tmp
 
         if abs(self.ratiometric_offs_B12) > 0:
-            basename = os.path.splitext(os.path.basename(img_band12))[0]
             img_band12_tmp = os.path.join(
-                outputPath, "{}_tmpoffapply.kea".format(basename)
+                outputPath, "{}_B12_tmpoffapply.kea".format(basename)
             )
             exp = "b1 + {}".format(self.ratiometric_offs_B12)
             rsgislib.imagecalc.image_math(


### PR DESCRIPTION
…queness

A fix was done in generateOutputBaseName to add the generation time to avoid output filenames potentially being the same for "split" granules. generateOutputBaseName isn't applied to non-resampled bands in convertImageToRadiance, so this change applies it to those bands which seems to fully fix the issue for us.